### PR TITLE
Only use file basename (avoid path traversal)

### DIFF
--- a/admin/app/routes.py
+++ b/admin/app/routes.py
@@ -1,18 +1,27 @@
 def routes():
-    from .data import Endpoints, IDFiles, IDResults, IDs, Info, Logs
+    from .data import Endpoints, IDDelete, IDFiles, IDResults, IDs, Info, Logs
     p = paths()
     endpoints = Endpoints()
+    id_delete = IDDelete()
     id_files = IDFiles()
     id_results = IDResults()
     ids = IDs()
     info = Info()
     logs = Logs()
-    funcs = [endpoints, id_files, id_results, ids, info, logs]
+    funcs = [endpoints, id_delete, id_files, id_results, ids, info, logs]
     return dict(zip(p, funcs))
 
 
 def paths():
-    return ['', '/id/files', '/id/results', '/ids', '/info', '/logs/{req_id}']
+    return [
+        '',
+        '/id/delete/{session_id}',
+        '/id/files',
+        '/id/results',
+        '/ids',
+        '/info',
+        '/logs/{req_id}'
+    ]
 
 
 def version():

--- a/design/api.md
+++ b/design/api.md
@@ -25,7 +25,7 @@ Returns a list of the available API endpoints for this service.
 {% endapi-method-response-example-description %}
 
 ```
-["/v1", "/v1/id/files", "/v1/id/results", "/v1/ids", "/v1/info", "/v1/logs/{req_id}"]
+["/v1", "/v1/id/delete/{session_id}", "/v1/id/files", "/v1/id/results", "/v1/ids", "/v1/info", "/v1/logs/{req_id}"]
 ```
 {% endapi-method-response-example %}
 {% endapi-method-response %}
@@ -543,6 +543,38 @@ Session ID
 
 ```
 TO BE IMPLEMENTED
+```
+{% endapi-method-response-example %}
+{% endapi-method-response %}
+{% endapi-method-spec %}
+{% endapi-method %}
+
+{% api-method method="get" host="http://0.0.0.0" path="/api/v1/delete/:sess\_id" %}
+{% api-method-summary %}
+/api/v1/delete/:sess\_id
+{% endapi-method-summary %}
+
+{% api-method-description %}
+Deletes files and id directories associated with a session.
+{% endapi-method-description %}
+
+{% api-method-spec %}
+{% api-method-request %}
+{% api-method-path-parameters %}
+{% api-method-parameter name="sess\_id" type="string" required=true %}
+Session ID
+{% endapi-method-parameter %}
+{% endapi-method-path-parameters %}
+{% endapi-method-request %}
+
+{% api-method-response %}
+{% api-method-response-example httpCode=200 %}
+{% api-method-response-example-description %}
+
+{% endapi-method-response-example-description %}
+
+```
+{ "status": "Success" }
 ```
 {% endapi-method-response-example %}
 {% endapi-method-response %}

--- a/web/app/data.py
+++ b/web/app/data.py
@@ -367,8 +367,8 @@ class Upload(object):
 
         # Test if the file was uploaded
         if input_file.filename:
-            # Retrieve filename
-            filename = input_file.filename
+            # Retrieve file basename (avoid path traversal)
+            filename = os.path.basename(input_file.filename)
 
             uid = str(uuid.uuid4()).replace('-', '')
             file_dir = '/files/{0}/{1}'.format(session_id, uid)

--- a/web/app/routes.py
+++ b/web/app/routes.py
@@ -16,10 +16,19 @@ def routes():
 
 
 def paths():
-    return ['', '/id/{session_id}/{req_id}/{tool}/{pcap}/{counter}/{filename}',
-            '/ids/{session_id}',
-            '/info', '/raw/{tool}/{counter}/{session_id}/{req_id}', '/results/{tool}/{counter}/{session_id}/{req_id}', '/status/{session_id}/{req_id}',
-            '/stop/{session_id}/{req_id}', '/tools', '/upload']
+    return [
+        '',
+        '/id/{session_id}/{req_id}/{tool}/{pcap}/{counter}/{filename}',
+        '/ids/{session_id}',
+        '/info',
+        '/raw/{tool}/{counter}/{session_id}/{req_id}',
+        '/results/{tool}/{counter}/{session_id}/{req_id}',
+        '/status/{session_id}/{req_id}',
+        '/stop/{session_id}/{req_id}',
+        '/tools',
+        '/upload'
+    ]
+
 
 def version():
     return '/api/v1'


### PR DESCRIPTION
While working on a different pull request, I ran into a bug related to absolute and relative paths outside of cwd on ``upload``, e.g.: 

```
$ lim cafe upload notebooks/smallFlows.pcap
packet-cafe returned response: 502 Bad Gateway
$ lim cafe upload $(pwd)/test.pcap
packet-cafe returned response: 502 Bad Gateway
```

The error messages from the Docker container log suggest this also results in a path traversal issue (the ``notebooks/`` component results in an invalid path).

```
[2020-05-22 21:43:21 +0000] [15] [ERROR] Socket error processing request.
Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/gunicorn/workers/base_async.py", line 65, in handle
    util.reraise(*sys.exc_info())
  File "/usr/lib/python3.8/site-packages/gunicorn/util.py", line 625, in reraise
    raise value
  File "/usr/lib/python3.8/site-packages/gunicorn/workers/base_async.py", line 55, in handle
    self.handle_request(listener_name, req, client, addr)
  File "/usr/lib/python3.8/site-packages/gunicorn/workers/ggevent.py", line 143, in handle_request
    super().handle_request(listener_name, req, sock, addr)
  File "/usr/lib/python3.8/site-packages/gunicorn/workers/base_async.py", line 128, in handle_request
    util.reraise(*sys.exc_info())
  File "/usr/lib/python3.8/site-packages/gunicorn/util.py", line 625, in reraise
    raise value
  File "/usr/lib/python3.8/site-packages/gunicorn/workers/base_async.py", line 106, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
  File "/usr/lib/python3.8/site-packages/falcon/api.py", line 269, in __call__
    responder(req, resp, **params)
  File "/app/app/data.py", line 381, in on_post
    open(temp_file_path, 'wb').write(input_file.file.read())
FileNotFoundError: [Errno 2] No such file or directory: '/files/2ad5e089-084b-4adf-bf91-3698adda1fdc/6aef3b134d1844efa20075ab4ca3d319/notebooks/smal
lFlows.pcap~'
```

It appears a file name with path information in the API call is concatenated with the additional path information, which is not correct.

After applying this patch, it works.

```
$ lim cafe upload $(pwd)/test.pcap
test.pcap success sess_id: bc144254-25df-48c7-aa8a-ae4249f70864 req_id: 04591504ead54f7e8b589ce16174f43d
pcap-stats complete 2020-05-23T00:02:30.863687+00:00
pcap-dot1q complete 2020-05-23T00:02:30.631356+00:00
ncapture complete 2020-05-23T00:02:26.674475+00:00
mercury complete 2020-05-23T00:02:32.673042+00:00
snort complete 2020-05-23T00:02:35.261851+00:00
pcap-splitter complete 2020-05-23T00:02:41.688210+00:00
pcapplot complete 2020-05-23T00:03:23.618988+00:00
networkml complete 2020-05-23T00:03:51.153369+00:00
p0f complete 2020-05-23T00:04:02.443223+00:00
```
